### PR TITLE
feat: add support for using teslamate geofences

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -135,7 +135,18 @@ func main() {
 	for _, car := range cars {
 		log.Printf("Subscribing to MQTT geofence, latitude, and longitude topics for car %d", car.ID)
 
-		for _, topic := range []string{"geofence", "latitude", "longitude"} {
+		topics := make([]string, 0)
+		if car.GarageDoor.TriggerCloseGeofence.IsGeofenceDefined() && car.GarageDoor.TriggerOpenGeofence.IsGeofenceDefined() {
+			car.GarageDoor.UseTeslmateGeofence = true
+			topics = append(topics, "geofence")
+		} else if car.GarageDoor.Location.IsPointDefined() {
+			topics = append(topics, "latitude", "longitude")
+			car.GarageDoor.UseTeslmateGeofence = false
+		} else {
+			log.Fatalf("must define a valid location and radii for garage door or open and close geofence triggers")
+		}
+
+		for _, topic := range topics {
 			if token := client.Subscribe(
 				fmt.Sprintf("teslamate/cars/%d/%s", car.ID, topic),
 				0,
@@ -171,6 +182,8 @@ func main() {
 			switch m[3] {
 			case "geofence":
 				log.Printf("Received geo for car %d: %v", car.ID, string(message.Payload()))
+				car.CurGeofence = string(message.Payload())
+				go geo.CheckGeoFence(util.Config, car)
 			case "latitude":
 				if debug {
 					log.Printf("Received lat for car %d: %v", car.ID, string(message.Payload()))

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -133,7 +133,7 @@ func main() {
 
 	// create channels to receive messages
 	for _, car := range cars {
-		log.Printf("Subscribing to MQTT geofence, latitude, and longitude topics for car %d", car.ID)
+		log.Printf("Subscribing to MQTT topics for car %d", car.ID)
 
 		topics := make([]string, 0)
 		if car.GarageDoor.TriggerCloseGeofence.IsGeofenceDefined() && car.GarageDoor.TriggerOpenGeofence.IsGeofenceDefined() {
@@ -182,6 +182,7 @@ func main() {
 			switch m[3] {
 			case "geofence":
 				log.Printf("Received geo for car %d: %v", car.ID, string(message.Payload()))
+				car.PrevGeofence = car.CurGeofence
 				car.CurGeofence = string(message.Payload())
 				go geo.CheckGeoFence(util.Config, car)
 			case "latitude":

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -181,9 +181,9 @@ func main() {
 			// if lat or lng received, check geofence
 			switch m[3] {
 			case "geofence":
-				log.Printf("Received geo for car %d: %v", car.ID, string(message.Payload()))
 				car.PrevGeofence = car.CurGeofence
 				car.CurGeofence = string(message.Payload())
+				log.Printf("Received geo for car %d: %v", car.ID, car.CurGeofence)
 				go geo.CheckGeoFence(util.Config, car)
 			case "latitude":
 				if debug {

--- a/config.example.yml
+++ b/config.example.yml
@@ -16,7 +16,7 @@ global:
   myq_pass: super_secret_password # password to auth to myq account; can also be passed as env var MYQ_PASS
 
 garage_doors:
-  - &main_door
+  - # main garage
     location: # defines the latitude and longitude of the garage door location, which will be the center of the geofence radius
       lat: 48.858195
       lng: 2.294689
@@ -26,10 +26,13 @@ garage_doors:
     cars:
       - teslamage_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
       - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker
-  - <<: *main_door # will inherit all properties defined in the first garage_door, with overrides listed below
-    location:
-      lat: 48.858197
-      lng: 2.294689
-    myq_serial: myq_serial_2
+  - # 3rd car garage
+    trigger_close_geofence:
+      from: home
+      to: close_to_home
+    trigger_open_geofence:
+      from: not_home
+      to: close_to_home
+    myq_serial: myq_serial_2 # serial number of garage door opener; see README for more info
     cars:
-      - teslamate_car_id: 3
+      - teslamage_car_id: 3 # id used for the third vehicle in TeslaMate's MQTT broker

--- a/config.example.yml
+++ b/config.example.yml
@@ -27,10 +27,10 @@ garage_doors:
       - teslamage_car_id: 1 # id used for the first vehicle in TeslaMate's MQTT broker
       - teslamate_car_id: 2 # id used for the second vehicle in TeslaMate's MQTT broker
   - # 3rd car garage
-    trigger_close_geofence:
+    trigger_close_geofence: # this method is not yet fully released, but is available for preview in v0.1.2-rc1; please use location, close_radius, and open_radius for latest full release versions
       from: home
       to: close_to_home
-    trigger_open_geofence:
+    trigger_open_geofence: # this method is not yet fully released, but is available for preview in v0.1.2-rc1; please use location, close_radius, and open_radius for latest full release versions
       from: not_home
       to: close_to_home
     myq_serial: myq_serial_2 # serial number of garage door opener; see README for more info

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -141,8 +141,6 @@ func getGeoChangeEventAction(config util.ConfigStruct, car *util.Car) string {
 		car.CurGeofence == car.GarageDoor.TriggerOpenGeofence.To {
 		action = "open"
 	}
-	car.PrevGeofence = car.CurGeofence
-	car.CurGeofence = ""
 	return action
 }
 

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -17,6 +17,8 @@ type testParamsStruct struct {
 	loginCount        int
 	deviceStateCount  int
 	setDoorStateCount int
+	openActionCount   int
+	closeActionCount  int
 }
 
 var (
@@ -27,8 +29,11 @@ var (
 	loginError             error
 	setDoorStateError      error
 
-	car        *util.Car
-	garageDoor *util.GarageDoor
+	distanceCar        *util.Car
+	distanceGarageDoor *util.GarageDoor
+
+	geofenceGarageDoor *util.GarageDoor
+	geofenceCar        *util.Car
 )
 
 func (m *MockMyqSession) SetUsername(s string) {
@@ -51,6 +56,11 @@ func (m *MockMyqSession) Login() error {
 
 func (m *MockMyqSession) SetDoorState(serialNumber, action string) error {
 	testParams.setDoorStateCount++
+	if action == "open" {
+		testParams.openActionCount++
+	} else if action == "close" {
+		testParams.closeActionCount++
+	}
 	return setDoorStateError
 }
 
@@ -58,28 +68,37 @@ func (m *MockMyqSession) New() {}
 
 func init() {
 	util.LoadConfig(filepath.Join("..", "..", "config.example.yml"))
-	garageDoor = util.Config.GarageDoors[0]
-	car = garageDoor.Cars[0]
-	car.GarageDoor = garageDoor
+
+	// used for testing events based on distance
+	distanceGarageDoor = util.Config.GarageDoors[0]
+	distanceCar = distanceGarageDoor.Cars[0]
+	distanceCar.GarageDoor = distanceGarageDoor
+
+	// used for testing events based on geofence changes
+	geofenceGarageDoor = util.Config.GarageDoors[1]
+	geofenceCar = geofenceGarageDoor.Cars[0]
+	geofenceCar.GarageDoor = geofenceGarageDoor
+	geofenceCar.GarageDoor.UseTeslmateGeofence = true
+
 	util.Config.Global.OpCooldown = 0
 	myqExec = &MockMyqSession{}
 }
 
-func Test_CheckGeoFence_Leaving(t *testing.T) {
+func Test_CheckGeoFence_DistanceTrigger_Leaving(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// TEST 1 - Leaving home, garage close
-	car.CurDistance = 0
+	distanceCar.CurDistance = 0
 	testParams = &testParamsStruct{}
-	car.CurLat = garageDoor.Location.Lat + 10
-	car.CurLng = garageDoor.Location.Lng
+	distanceCar.CurLat = distanceGarageDoor.Location.Lat + 10
+	distanceCar.CurLng = distanceGarageDoor.Location.Lng
 
 	deviceStateReturnValue = "open"
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		CheckGeoFence(util.Config, car)
+		CheckGeoFence(util.Config, distanceCar)
 	}()
 	// wait for SetGarageDoor call and then update call
 	for {
@@ -101,17 +120,17 @@ func Test_CheckGeoFence_Leaving(t *testing.T) {
 	}
 }
 
-func Test_CheckGeofence_LeaveRetry(t *testing.T) {
+func Test_CheckGeofence_DistanceTrigger_LeaveRetry(t *testing.T) {
 	// TEST 2 - Leaving home, garage close, fail and retry 3 times
-	car.CurDistance = 0
+	distanceCar.CurDistance = 0
 	testParams = &testParamsStruct{}
-	car.CurLat = garageDoor.Location.Lat + 10
-	car.CurLng = garageDoor.Location.Lng
+	distanceCar.CurLat = distanceGarageDoor.Location.Lat + 10
+	distanceCar.CurLng = distanceGarageDoor.Location.Lng
 
 	deviceStateReturnValue = "open"
 	setDoorStateError = fmt.Errorf("mock error")
 
-	CheckGeoFence(util.Config, car)
+	CheckGeoFence(util.Config, distanceCar)
 
 	want := []int{3, 3, 3, 3}
 	got := []int{testParams.setUsernameCount,
@@ -125,12 +144,12 @@ func Test_CheckGeofence_LeaveRetry(t *testing.T) {
 	}
 }
 
-func Test_CheckGeofence_Arrive(t *testing.T) {
+func Test_CheckGeofence_DistanceTrigger_Arrive(t *testing.T) {
 	// TEST 3 - Arriving Home
-	car.CurDistance = 1
+	distanceCar.CurDistance = 1
 	testParams = &testParamsStruct{}
-	car.CurLat = garageDoor.Location.Lat
-	car.CurLng = garageDoor.Location.Lng
+	distanceCar.CurLat = distanceGarageDoor.Location.Lat
+	distanceCar.CurLng = distanceGarageDoor.Location.Lng
 	var wg sync.WaitGroup
 
 	deviceStateReturnValue = "closed"
@@ -139,7 +158,7 @@ func Test_CheckGeofence_Arrive(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		CheckGeoFence(util.Config, car)
+		CheckGeoFence(util.Config, distanceCar)
 	}()
 	// wait for SetGarageDoor call and then update call
 	for {
@@ -159,5 +178,222 @@ func Test_CheckGeofence_Arrive(t *testing.T) {
 
 	if !reflect.DeepEqual(want, got) {
 		t.Errorf("Test 3 failed, got %v, want %v", got, want)
+	}
+}
+
+func Test_CheckGeofence_DistanceTrigger_Leave_Then_Arrive(t *testing.T) {
+	distanceCar.CurDistance = 0
+	distanceCar.CurLat = distanceCar.GarageDoor.Location.Lat + 1
+	distanceCar.CurLng = distanceCar.GarageDoor.Location.Lng
+	testParams = &testParamsStruct{}
+	var wg sync.WaitGroup
+
+	deviceStateReturnValue = "open"
+	deviceStateReturnError = nil
+	setDoorStateError = nil
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		CheckGeoFence(util.Config, distanceCar)
+	}()
+	// wait for SetGarageDoor call and then update call
+	for {
+		if testParams.setDoorStateCount > 0 {
+			deviceStateReturnValue = "closed"
+			break
+		}
+	}
+	wg.Wait()
+
+	// check garage would've been closed
+	want := []int{1, 1, 1, 1, 1}
+	got := []int{testParams.setUsernameCount,
+		testParams.setPasswordCount,
+		testParams.loginCount,
+		testParams.setDoorStateCount,
+		testParams.closeActionCount,
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("leave function call counts failed, got %v, want %v", got, want)
+	}
+
+	distanceCar.CurLat = distanceCar.CurLat + 1
+	prevDistance := distanceCar.CurDistance
+	CheckGeoFence(util.Config, distanceCar) // should return no-op but will update geofenceCar.PrevGeofence
+	if prevDistance == distanceCar.CurDistance {
+		t.Errorf("update CurDistance failed")
+	}
+
+	distanceCar.CurLat = distanceCar.GarageDoor.Location.Lat
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		CheckGeoFence(util.Config, distanceCar)
+	}()
+	// wait for SetGarageDoor call and then update call
+	for {
+		if testParams.setDoorStateCount > 1 {
+			deviceStateReturnValue = "open"
+			break
+		}
+	}
+	wg.Wait()
+
+	// check garage would've been opened
+	want = []int{2, 2, 2, 2, 1}
+	got = []int{testParams.setUsernameCount,
+		testParams.setPasswordCount,
+		testParams.loginCount,
+		testParams.setDoorStateCount,
+		testParams.openActionCount,
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("arrive function call counts failed, got %v, want %v", got, want)
+	}
+}
+
+func Test_CheckGeoFence_GeofenceTrigger_Leaving(t *testing.T) {
+	var wg sync.WaitGroup
+
+	// TEST 1 - Leaving home, garage close
+	geofenceCar.PrevGeofence = "home"
+	geofenceCar.CurGeofence = "close_to_home"
+	testParams = &testParamsStruct{}
+
+	deviceStateReturnValue = "open"
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		CheckGeoFence(util.Config, geofenceCar)
+	}()
+	// wait for SetGarageDoor call and then update call
+	for {
+		if testParams.setDoorStateCount > 0 {
+			deviceStateReturnValue = "closed"
+			break
+		}
+	}
+	wg.Wait()
+	want := []int{1, 1, 1, 1}
+	got := []int{testParams.setUsernameCount,
+		testParams.setPasswordCount,
+		testParams.loginCount,
+		testParams.setDoorStateCount,
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("Test 1 failed, got %v, want %v", got, want)
+	}
+}
+
+func Test_CheckGeofence_GeofenceTrigger_Arrive(t *testing.T) {
+	geofenceCar.PrevGeofence = "not_home"
+	geofenceCar.CurGeofence = "close_to_home"
+	testParams = &testParamsStruct{}
+	var wg sync.WaitGroup
+
+	deviceStateReturnValue = "closed"
+	deviceStateReturnError = nil
+	setDoorStateError = nil
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		CheckGeoFence(util.Config, geofenceCar)
+	}()
+	// wait for SetGarageDoor call and then update call
+	for {
+		if testParams.setDoorStateCount > 0 {
+			deviceStateReturnValue = "open"
+			break
+		}
+	}
+	wg.Wait()
+
+	want := []int{1, 1, 1, 1}
+	got := []int{testParams.setUsernameCount,
+		testParams.setPasswordCount,
+		testParams.loginCount,
+		testParams.setDoorStateCount,
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("Test 3 failed, got %v, want %v", got, want)
+	}
+}
+
+func Test_CheckGeofence_GeofenceTrigger_Leave_Then_Arrive(t *testing.T) {
+	geofenceCar.PrevGeofence = "home"
+	geofenceCar.CurGeofence = "close_to_home"
+	testParams = &testParamsStruct{}
+	var wg sync.WaitGroup
+
+	deviceStateReturnValue = "open"
+	deviceStateReturnError = nil
+	setDoorStateError = nil
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		CheckGeoFence(util.Config, geofenceCar)
+	}()
+	// wait for SetGarageDoor call and then update call
+	for {
+		if testParams.setDoorStateCount > 0 {
+			deviceStateReturnValue = "closed"
+			break
+		}
+	}
+	wg.Wait()
+
+	// check garage would've been closed
+	want := []int{1, 1, 1, 1, 1}
+	got := []int{testParams.setUsernameCount,
+		testParams.setPasswordCount,
+		testParams.loginCount,
+		testParams.setDoorStateCount,
+		testParams.closeActionCount,
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("leave function call counts failed, got %v, want %v", got, want)
+	}
+
+	geofenceCar.CurGeofence = "not_home"
+	CheckGeoFence(util.Config, geofenceCar) // should return no-op but will update geofenceCar.PrevGeofence
+	if geofenceCar.PrevGeofence != "not_home" {
+		t.Errorf("update PrevGeofence failed, got %s, want %s", geofenceCar.PrevGeofence, "not_home")
+	}
+
+	geofenceCar.CurGeofence = "close_to_home"
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		CheckGeoFence(util.Config, geofenceCar)
+	}()
+	// wait for SetGarageDoor call and then update call
+	for {
+		if testParams.setDoorStateCount > 1 {
+			deviceStateReturnValue = "open"
+			break
+		}
+	}
+	wg.Wait()
+
+	// check garage would've been opened
+	want = []int{2, 2, 2, 2, 1}
+	got = []int{testParams.setUsernameCount,
+		testParams.setPasswordCount,
+		testParams.loginCount,
+		testParams.setDoorStateCount,
+		testParams.openActionCount,
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("arrive function call counts failed, got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Allows using Geofences defined in TeslaMate rather than manually specifying a lat/long center point with radii. Some observations regarding this method:

* Geo does not update as frequently as lat/long in MQTT, so there is quite a delay in actually triggering the garage action
  * Presumably this is because the Geofence isn't calculated in realtime with every lat/long update like Tesla-YouQ does, but this is an assumption
* TeslaMate doesn't seem to have any logic for distinction between overlapping geofences. For example, with 2 geofences that have the same center point but different radii, TeslaMate exhibits unpredictable behavior with which geofence gets ascribed to the location
  * This limitation means this method should really only be used for a single geofence, meaning open and close events cannot be defined separately
    * This PR will still support having separate geo's but is at the mercy of the data it receives from TeslaMate; if this is ever fixed, then Tesla-YouQ will already support it, but in the meantime, users should stick to a single geofence
* This method requires defining a `DEFAULT_GEOFENCE` environment variable for TeslaMate (such as `not_home`), as some string must be published to the MQTT broker to trigger an event.
  * See [this PR](https://github.com/adriankumpf/teslamate/pull/2564) in TeslaMate for more info