### PR TITLE
feat: add lat lng to op output and thread safety

### DIFF
--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -124,7 +124,7 @@ func CheckGeofence(config util.ConfigStruct, car *util.Car) {
 
 // gets action based on if there was a relevant distance change
 func getDistanceChangeAction(config util.ConfigStruct, car *util.Car) (action string) {
-	if car.CurrentLocation.IsPointDefined() {
+	if !car.CurrentLocation.IsPointDefined() {
 		return // need valid lat and lng to check fence
 	}
 
@@ -156,7 +156,7 @@ func getGeoChangeEventAction(config util.ConfigStruct, car *util.Car) (action st
 // get action based on whether we had a polygon geofence change event
 // uses ray-casting algorithm, assumes a simple geofence (no holes or border cross points)
 func getPolygonGeoChangeEventAction(config util.ConfigStruct, car *util.Car) (action string) {
-	if car.CurrentLocation.IsPointDefined() {
+	if !car.CurrentLocation.IsPointDefined() {
 		return "" // need valid lat and long to check geofence
 	}
 

--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -94,7 +94,7 @@ func CheckGeofence(config util.ConfigStruct, car *util.Car) {
 	}
 
 	car.GarageDoor.OpLock = true // set lock so no other threads try to operate the garage before the cooldown period is complete
-	log.Printf("Attempting to %s garage door for car %d", action, car.ID)
+	log.Printf("Attempting to %s garage door for car %d at lat %f, long %f", action, car.ID, car.CurLat, car.CurLng)
 
 	// create retry loop to set the garage door state
 	for i := 3; i > 0; i-- {

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -128,6 +128,12 @@ func Test_CheckCircularGeofence_Leaving_NotLoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !distanceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckCircularGeofence_Leaving_LoggedIn(t *testing.T) {
@@ -146,6 +152,12 @@ func Test_CheckCircularGeofence_Leaving_LoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !distanceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckCircularGeofence_Arriving_LoggedIn(t *testing.T) {
@@ -164,6 +176,12 @@ func Test_CheckCircularGeofence_Arriving_LoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !distanceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckCircularGeofence_Arriving_LoggedIn_Retry(t *testing.T) {
@@ -183,6 +201,12 @@ func Test_CheckCircularGeofence_Arriving_LoggedIn_Retry(t *testing.T) {
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !distanceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
@@ -206,6 +230,12 @@ func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !distanceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 
 	myqSession.AssertExpectations(t) // midpoint check
 
@@ -217,6 +247,12 @@ func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !distanceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckTeslamateGeofence_Leaving_LoggedIn(t *testing.T) {
@@ -234,6 +270,12 @@ func Test_CheckTeslamateGeofence_Leaving_LoggedIn(t *testing.T) {
 	geofenceCar.CurGeofence = "not_home"
 
 	CheckGeofence(util.Config, geofenceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !geofenceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckTeslamateGeofence_Arriving_LoggedIn(t *testing.T) {
@@ -251,6 +293,12 @@ func Test_CheckTeslamateGeofence_Arriving_LoggedIn(t *testing.T) {
 	geofenceCar.CurGeofence = "home"
 
 	CheckGeofence(util.Config, geofenceCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !geofenceCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckPolyGeofence_Leaving_NotLoggedIn(t *testing.T) {
@@ -275,6 +323,12 @@ func Test_CheckPolyGeofence_Leaving_NotLoggedIn(t *testing.T) {
 	polygonCar.CurrentLocation.Lng = -123.79984989897177
 
 	CheckGeofence(util.Config, polygonCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !polygonCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }
 
 func Test_CheckPolyGeofence_Arriving_LoggedIn(t *testing.T) {
@@ -294,4 +348,10 @@ func Test_CheckPolyGeofence_Arriving_LoggedIn(t *testing.T) {
 	polygonCar.CurrentLocation.Lng = -123.80103692981524
 
 	CheckGeofence(util.Config, polygonCar)
+	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
+	for {
+		if !polygonCar.GarageDoor.OpLock {
+			break
+		}
+	}
 }

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -50,13 +50,13 @@ func init() {
 
 func Test_getDistanceChangeAction(t *testing.T) {
 	distanceCar.CurDistance = 0
-	distanceCar.CurLat = distanceCar.GarageDoor.CircularGeofence.Center.Lat + 10
-	distanceCar.CurLng = distanceCar.GarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceCar.GarageDoor.CircularGeofence.Center.Lat + 10
+	distanceCar.CurrentLocation.Lng = distanceCar.GarageDoor.CircularGeofence.Center.Lng
 
 	assert.Equal(t, myq.ActionClose, getDistanceChangeAction(util.Config, distanceCar))
 	assert.Greater(t, distanceCar.CurDistance, distanceCar.GarageDoor.CircularGeofence.CloseDistance)
 
-	distanceCar.CurLat = distanceCar.GarageDoor.CircularGeofence.Center.Lat
+	distanceCar.CurrentLocation.Lat = distanceCar.GarageDoor.CircularGeofence.Center.Lat
 
 	assert.Equal(t, myq.ActionOpen, getDistanceChangeAction(util.Config, distanceCar))
 	assert.Less(t, distanceCar.CurDistance, distanceCar.GarageDoor.CircularGeofence.OpenDistance)
@@ -93,16 +93,16 @@ func Test_isInsidePolygonGeo(t *testing.T) {
 func Test_getPolygonGeoChangeEventAction(t *testing.T) {
 	polygonCar.InsidePolyCloseGeo = true
 	polygonCar.InsidePolyOpenGeo = true
-	polygonCar.CurLat = 46.19292902096646
-	polygonCar.CurLng = -123.79984989897177
+	polygonCar.CurrentLocation.Lat = 46.19292902096646
+	polygonCar.CurrentLocation.Lng = -123.79984989897177
 
 	assert.Equal(t, myq.ActionClose, getPolygonGeoChangeEventAction(util.Config, polygonCar))
 	assert.Equal(t, false, polygonCar.InsidePolyCloseGeo)
 	assert.Equal(t, true, polygonCar.InsidePolyOpenGeo)
 
 	polygonCar.InsidePolyOpenGeo = false
-	polygonCar.CurLat = 46.19243683948096
-	polygonCar.CurLng = -123.80103692981524
+	polygonCar.CurrentLocation.Lat = 46.19243683948096
+	polygonCar.CurrentLocation.Lng = -123.80103692981524
 
 	assert.Equal(t, myq.ActionOpen, getPolygonGeoChangeEventAction(util.Config, polygonCar))
 }
@@ -124,8 +124,8 @@ func Test_CheckCircularGeofence_Leaving_NotLoggedIn(t *testing.T) {
 	myqSession.EXPECT().SetDoorState(mock.AnythingOfType("string"), myq.ActionClose).Return(nil).Once()
 
 	distanceCar.CurDistance = 0
-	distanceCar.CurLat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
-	distanceCar.CurLng = distanceGarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
+	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
 }
@@ -142,8 +142,8 @@ func Test_CheckCircularGeofence_Leaving_LoggedIn(t *testing.T) {
 	myqSession.EXPECT().SetDoorState(mock.AnythingOfType("string"), myq.ActionClose).Return(nil).Once()
 
 	distanceCar.CurDistance = 0
-	distanceCar.CurLat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
-	distanceCar.CurLng = distanceGarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
+	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
 }
@@ -160,8 +160,8 @@ func Test_CheckCircularGeofence_Arriving_LoggedIn(t *testing.T) {
 	myqSession.EXPECT().SetDoorState(mock.AnythingOfType("string"), myq.ActionOpen).Return(nil).Once()
 
 	distanceCar.CurDistance = 100
-	distanceCar.CurLat = distanceGarageDoor.CircularGeofence.Center.Lat
-	distanceCar.CurLng = distanceGarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat
+	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
 }
@@ -179,8 +179,8 @@ func Test_CheckCircularGeofence_Arriving_LoggedIn_Retry(t *testing.T) {
 	myqSession.EXPECT().DeviceState(mock.AnythingOfType("string")).Return(myq.StateOpen, nil).Once()
 
 	distanceCar.CurDistance = 100
-	distanceCar.CurLat = distanceGarageDoor.CircularGeofence.Center.Lat
-	distanceCar.CurLng = distanceGarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat
+	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
 }
@@ -202,8 +202,8 @@ func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
 	myqSession.EXPECT().DeviceState(mock.AnythingOfType("string")).Return(myq.StateClosed, nil).Once()
 
 	distanceCar.CurDistance = 0
-	distanceCar.CurLat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
-	distanceCar.CurLng = distanceGarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
+	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
 
@@ -213,8 +213,8 @@ func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
 	myqSession.EXPECT().DeviceState(mock.AnythingOfType("string")).Return(myq.StateClosed, nil).Once()
 	myqSession.EXPECT().SetDoorState(mock.AnythingOfType("string"), myq.ActionOpen).Return(nil).Once()
 	myqSession.EXPECT().DeviceState(mock.AnythingOfType("string")).Return(myq.StateOpen, nil).Once()
-	distanceCar.CurLat = distanceGarageDoor.CircularGeofence.Center.Lat
-	distanceCar.CurLng = distanceGarageDoor.CircularGeofence.Center.Lng
+	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat
+	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
 	CheckGeofence(util.Config, distanceCar)
 }
@@ -271,8 +271,8 @@ func Test_CheckPolyGeofence_Leaving_NotLoggedIn(t *testing.T) {
 
 	polygonCar.InsidePolyCloseGeo = true
 	polygonCar.InsidePolyOpenGeo = true
-	polygonCar.CurLat = 46.19292902096646
-	polygonCar.CurLng = -123.79984989897177
+	polygonCar.CurrentLocation.Lat = 46.19292902096646
+	polygonCar.CurrentLocation.Lng = -123.79984989897177
 
 	CheckGeofence(util.Config, polygonCar)
 }
@@ -290,8 +290,8 @@ func Test_CheckPolyGeofence_Arriving_LoggedIn(t *testing.T) {
 
 	polygonCar.InsidePolyCloseGeo = false
 	polygonCar.InsidePolyOpenGeo = false
-	polygonCar.CurLat = 46.19243683948096
-	polygonCar.CurLng = -123.80103692981524
+	polygonCar.CurrentLocation.Lat = 46.19243683948096
+	polygonCar.CurrentLocation.Lng = -123.80103692981524
 
 	CheckGeofence(util.Config, polygonCar)
 }

--- a/internal/geo/geo_test.go
+++ b/internal/geo/geo_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/brchri/tesla-youq/internal/mocks"
 	"github.com/joeshaw/myq"
@@ -127,13 +128,7 @@ func Test_CheckCircularGeofence_Leaving_NotLoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
-	CheckGeofence(util.Config, distanceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !distanceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
 }
 
 func Test_CheckCircularGeofence_Leaving_LoggedIn(t *testing.T) {
@@ -151,13 +146,7 @@ func Test_CheckCircularGeofence_Leaving_LoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat + 10
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
-	CheckGeofence(util.Config, distanceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !distanceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
 }
 
 func Test_CheckCircularGeofence_Arriving_LoggedIn(t *testing.T) {
@@ -175,13 +164,7 @@ func Test_CheckCircularGeofence_Arriving_LoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
-	CheckGeofence(util.Config, distanceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !distanceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
 }
 
 func Test_CheckCircularGeofence_Arriving_LoggedIn_Retry(t *testing.T) {
@@ -200,13 +183,7 @@ func Test_CheckCircularGeofence_Arriving_LoggedIn_Retry(t *testing.T) {
 	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
-	CheckGeofence(util.Config, distanceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !distanceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
 }
 
 func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
@@ -246,13 +223,7 @@ func Test_CheckCircularGeofence_LeaveThenArrive_NotLoggedIn(t *testing.T) {
 	distanceCar.CurrentLocation.Lat = distanceGarageDoor.CircularGeofence.Center.Lat
 	distanceCar.CurrentLocation.Lng = distanceGarageDoor.CircularGeofence.Center.Lng
 
-	CheckGeofence(util.Config, distanceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !distanceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(distanceCar), true)
 }
 
 func Test_CheckTeslamateGeofence_Leaving_LoggedIn(t *testing.T) {
@@ -269,13 +240,7 @@ func Test_CheckTeslamateGeofence_Leaving_LoggedIn(t *testing.T) {
 	geofenceCar.PrevGeofence = "home"
 	geofenceCar.CurGeofence = "not_home"
 
-	CheckGeofence(util.Config, geofenceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !geofenceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(geofenceCar), true)
 }
 
 func Test_CheckTeslamateGeofence_Arriving_LoggedIn(t *testing.T) {
@@ -292,13 +257,7 @@ func Test_CheckTeslamateGeofence_Arriving_LoggedIn(t *testing.T) {
 	geofenceCar.PrevGeofence = "not_home"
 	geofenceCar.CurGeofence = "home"
 
-	CheckGeofence(util.Config, geofenceCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !geofenceCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(geofenceCar), true)
 }
 
 func Test_CheckPolyGeofence_Leaving_NotLoggedIn(t *testing.T) {
@@ -322,13 +281,7 @@ func Test_CheckPolyGeofence_Leaving_NotLoggedIn(t *testing.T) {
 	polygonCar.CurrentLocation.Lat = 46.19292902096646
 	polygonCar.CurrentLocation.Lng = -123.79984989897177
 
-	CheckGeofence(util.Config, polygonCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !polygonCar.GarageDoor.OpLock {
-			break
-		}
-	}
+	assert.Equal(t, checkGeofenceWrapper(polygonCar), true)
 }
 
 func Test_CheckPolyGeofence_Arriving_LoggedIn(t *testing.T) {
@@ -347,11 +300,19 @@ func Test_CheckPolyGeofence_Arriving_LoggedIn(t *testing.T) {
 	polygonCar.CurrentLocation.Lat = 46.19243683948096
 	polygonCar.CurrentLocation.Lng = -123.80103692981524
 
-	CheckGeofence(util.Config, polygonCar)
-	// wait for oplock to release to ensure goroutine within CheckGeofence function has completed
-	for {
-		if !polygonCar.GarageDoor.OpLock {
-			break
+	assert.Equal(t, checkGeofenceWrapper(polygonCar), true)
+}
+
+// runs CheckGeofence and waits for the internal goroutine to complete, signified by the release of oplock,
+// with 100 ms timeout
+func checkGeofenceWrapper(car *util.Car) bool {
+	CheckGeofence(util.Config, car)
+	// wait for oplock to be released with a 100 ms timeout
+	for i := 0; i < 10; i++ {
+		if !car.GarageDoor.OpLock {
+			return true
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
+	return false
 }

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -61,8 +61,8 @@ type (
 	Car struct {
 		ID                 int         `yaml:"teslamate_car_id"` // mqtt identifier for vehicle
 		GarageDoor         *GarageDoor // bidirectional pointer to GarageDoor containing car
-		CurLat             float64     // current latitude
-		CurLng             float64     // current longitude
+		CurrentLocation    Point       // current vehicle location
+		LocationUpdate     chan Point  // channel to receive location updates
 		CurDistance        float64     // current distance from garagedoor location
 		PrevGeofence       string      // geofence previously ascribed to car
 		CurGeofence        string      // updated geofence ascribed to car when published to mqtt
@@ -151,6 +151,11 @@ func LoadConfig(configFile string) {
 		g.GeofenceType = g.GetGeofenceType()
 		if g.GeofenceType == "" {
 			log.Fatalf("error: no supported geofences defined for garage door %v", g)
+		}
+
+		// initialize location update channel
+		for _, c := range g.Cars {
+			c.LocationUpdate = make(chan Point, 2)
 		}
 	}
 


### PR DESCRIPTION
Whenever a garage operation is triggered, it will now display the lat and long values that triggered the operation. In addition, some thread safety handling mechanisms have been put in place to ensure we don't get race conditions when processing simultaneous lat and long updates.